### PR TITLE
chore: sync template from tschm/latex@main

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,34 +1,25 @@
-# Workflow to run pre-commit checks on the codebase
-# This workflow runs automatically on every push to the repository
-
-name: pre-commit
+name: Pre-commit
 
 on:
-  push:  # Trigger on push events
-
-# Only read access is needed for pre-commit checks
-permissions:
-  contents: read  # Read-only access to repository contents
+  push:
+  pull_request:
 
 jobs:
-  # Job to run pre-commit checks on the repository
   pre-commit:
+    name: Pre-commit hooks
     runs-on: ubuntu-latest
+
     steps:
-      # Step 1: Check out the repository code
-      # This ensures we have the latest code from the specified ref
-      - name: Checkout [${{ github.repository }}]
-        uses: actions/checkout@v6  # Official GitHub checkout action
+      - uses: actions/checkout@v6.0.2
 
-      # Step 2: Set up Node.js environment
-      # This is required for some pre-commit hooks that use Node.js
-      - name: Install Node 22
-        uses: actions/setup-node@v6  # Official Node.js setup action
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
         with:
-          node-version: '24'  # Use Node.js version 22
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
 
-      # Step 3: Run all pre-commit hooks on all files
-      # This executes all hooks defined in .pre-commit-config.yaml
-      - uses: pre-commit/action@v3.0.1  # Official pre-commit GitHub Action
-        with:
-          extra_args: '--verbose --all-files'  # Run on all files with verbose output
+      - name: Run pre-commit
+        run: |
+          make fmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,40 +53,39 @@ jobs:
         with:
           path: compiled
 
-      - name: Check files
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Build site with MkDocs
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
+          TAG: ${{ github.event.inputs.tag }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          ls -all
-          tree
+          mkdir -p docs
 
-      - name: Generate index.html
-        run: |
-          # Extract repository name from github.repository (owner/repo)
-          REPO_NAME=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
-
-          # Copy the template file to the compiled directory
-          mkdir -p compiled
-          cp templates/index.html compiled/index.html
-
-          # Replace placeholders in the template
-          sed -i "s|{{ repo_name }}|${REPO_NAME}|g" compiled/index.html
-          sed -i "s|{{ tag }}|${{ github.event.inputs.tag }}|g" compiled/index.html
-          sed -i "s|{{ github_repo }}|${{ github.repository }}|g" compiled/index.html
-
-          # Insert PDF links into the template
-          # Create a string variable for PDF links
           find compiled -type f -name "*.pdf" | sort | while read -r file; do
-            rel_path=${file#compiled/}
-            filename=$(basename "$file")
-            printf "      <li class='hover:bg-gray-100 p-2 rounded transition-colors'><a href='%s' class='text-blue-600 hover:underline'>%s</a></li>\n" "$rel_path" "$filename"
-          done > pdf_links.txt
+            dest="docs/${file#compiled/}"
+            mkdir -p "$(dirname "$dest")"
+            cp "$file" "$dest"
+          done
 
-          sed -i "/{{ PDF_LINKS }}/{
-              r pdf_links.txt
-              d
-          }" compiled/index.html
+          {
+            echo "# ${REPO_NAME}"
+            echo ""
+            echo "Release: [${TAG}](https://github.com/${GH_REPO}/releases/tag/${TAG})"
+            echo ""
+            echo "## Documents"
+            echo ""
+            find docs -type f -name "*.pdf" | sort | while read -r f; do
+              rel="${f#docs/}"
+              echo "- [$(basename "$f")](${rel})"
+            done
+          } > docs/index.md
 
-          # Display the generated file
-          cat compiled/index.html
+          sed -i "s/^site_name:.*/site_name: ${REPO_NAME}/" mkdocs.yml
+
+          mkdocs build
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
@@ -102,7 +101,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: compiled
+          path: site
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,7 @@
 {
+  "MD010": {
+    "code_blocks": false
+  },
   "MD013": {
     "line_length": 120
   }

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,5 @@
-# Makefile for the paper project template
-# This Makefile provides commands for setting up the development environment,
-# compiling LaTeX documents, and maintaining code quality.
+## Makefile (repo-owned)
+# Keep this file small. It can be edited without breaking template sync.
 
-# Set the default target to 'help' when running make without arguments
-.DEFAULT_GOAL := help
-
-# Create a Python virtual environment using uv (faster alternative to venv)
-uv:
-	@curl -LsSf https://astral.sh/uv/install.sh | sh  # Install uv if not already installed
-
-
-# Mark 'help' as a phony target (not associated with a file)
-.PHONY: help
-help:  ## Display this help screen
-	@echo -e "\033[1mAvailable commands:\033[0m"  # Print header in bold
-	# Find all targets with comments (##) and display them as a help menu
-	# This grep/awk command extracts target names and their descriptions from the Makefile
-	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort
-
-
-# Mark 'compile' as a phony target
-.PHONY: compile
-compile: install ## Compile document(s)
-	./tectonic paper/document.tex
-
-
-# Mark 'clean' as a phony target
-.PHONY: clean
-clean: ## clean the folder
-	# Remove all files and directories that are ignored by git
-	# -d: include directories, -X: only remove files ignored by git, -f: force
-	@git clean -d -X -f
-
-
-# Mark 'install' as a phony target
-.PHONY: install
-install: ## install tectonic
-	# Download and install tectonic LaTeX compiler using the official installation script
-	@curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net | sh
-	# Display the current PATH to verify tectonic is accessible
-	@echo $PATH
-
-
-# Mark 'fmt' as a phony target
-.PHONY: fmt
-fmt: uv ## Run autoformatting and linting
-	@uvx pre-commit run --all-files  # Run all pre-commit hooks on all files
+# Always include the Rhiza API (template-managed)
+include .rhiza/rhiza.mk


### PR DESCRIPTION
This PR syncs the template from:
**tschm/latex @ main**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now runs on both pushes and pull requests and caches tooling environments for faster checks.
  * Pre-commit formatting checks consolidated into the CI flow.
  * Documentation generation migrated to MkDocs, with site artifacts deployed from the standard output directory.
  * Build tooling delegated to a shared makefile template.
  * Markdown linting configured to ignore code-block rule (MD010).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/demopaper/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->