### PR TITLE
chore: sync template from tschm/latex@v0.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 tectonic
 document.pdf
-site/
 
 # Instructions by the client
 sow.txt

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,5 @@
-# Makefile for the paper project template
-# This Makefile provides commands for setting up the development environment,
-# compiling LaTeX documents, and maintaining code quality.
+## Makefile (repo-owned)
+# Keep this file small. It can be edited without breaking template sync.
 
-# Set the default target to 'help' when running make without arguments
-.DEFAULT_GOAL := help
-
-# Create a Python virtual environment using uv (faster alternative to venv)
-uv:
-	@curl -LsSf https://astral.sh/uv/install.sh | sh  # Install uv if not already installed
-
-
-# Mark 'help' as a phony target (not associated with a file)
-.PHONY: help
-help:  ## Display this help screen
-	@echo -e "\033[1mAvailable commands:\033[0m"  # Print header in bold
-	# Find all targets with comments (##) and display them as a help menu
-	# This grep/awk command extracts target names and their descriptions from the Makefile
-	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort
-
-
-# Mark 'compile' as a phony target
-.PHONY: compile
-compile: install ## Compile document(s)
-	./tectonic paper/document.tex
-
-
-# Mark 'clean' as a phony target
-.PHONY: clean
-clean: ## clean the folder
-	# Remove all files and directories that are ignored by git
-	# -d: include directories, -X: only remove files ignored by git, -f: force
-	@git clean -d -X -f
-
-
-# Mark 'install' as a phony target
-.PHONY: install
-install: ## install tectonic
-	# Download and install tectonic LaTeX compiler using the official installation script
-	@curl --proto '=https' --tlsv1.2 -fsSL https://drop-sh.fullyjustified.net | sh
-	# Display the current PATH to verify tectonic is accessible
-	@echo $PATH
-
-
-# Mark 'fmt' as a phony target
-.PHONY: fmt
-fmt: uv ## Run autoformatting and linting
-	@uvx pre-commit run --all-files  # Run all pre-commit hooks on all files
-
--include .rhiza/rhiza.mk
+# Always include the Rhiza API (template-managed)
+include .rhiza/rhiza.mk


### PR DESCRIPTION
This PR syncs the template from:
**tschm/latex @ v0.0.6**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build system simplified by removing project-specific makefile targets and fully delegating to repository-provided template. Previously configured targets included virtual environment setup, help documentation, LaTeX compilation, cleanup, code formatting, and installation procedures.
  * Repository configuration updated to adjust directory exclusion patterns for cleaner version control management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tschm/demopaper/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->